### PR TITLE
feat(core): support nested sub menu

### DIFF
--- a/packages/core/src/menu/menuGroup.ts
+++ b/packages/core/src/menu/menuGroup.ts
@@ -4,12 +4,13 @@ export class MenuGroup {
   /**
    * the root wrapper Element
    */
-  element: HTMLDivElement = document.createElement('div')
+  readonly element: HTMLDivElement = document.createElement('div')
+  readonly menuItems: Set<MenuItem>
   constructor(
-    public readonly menuItems: MenuItem[] = [],
+    initialItems: MenuItem[] = [],
   ) {
-    // make a copy
-    this.menuItems = [...menuItems]
+    // dedupe
+    this.menuItems = new Set(initialItems)
   }
 
   /**
@@ -19,12 +20,23 @@ export class MenuGroup {
   add(...menuItems: MenuItem[]) {
     if (!Array.isArray(menuItems))
       menuItems = [menuItems]
-
     // store
-    this.menuItems.push(...menuItems)
-    // append to DOM
+    menuItems.forEach(item => this.menuItems.add(item))
+    // append to the DOM
     this.element.append(...menuItems.map(({ element }) => element))
     // tag
     menuItems.forEach(item => item.parentMenu = this)
+  }
+
+  remove(...menuItems: MenuItem[]) {
+    menuItems.forEach((item) => {
+      if (!this.menuItems.delete(item))
+        return
+
+      // remove item from the DOM
+      item.element.remove()
+      // clean tag
+      item.parentMenu = null
+    })
   }
 }

--- a/packages/core/src/menu/menuItem.ts
+++ b/packages/core/src/menu/menuItem.ts
@@ -12,7 +12,7 @@ export class MenuItem {
   /**
    * The parent menu group
    */
-  parentMenu!: MenuGroup
+  parentMenu: MenuGroup | null = null
 
   /**
    * Unregister mouse event listener
@@ -24,7 +24,7 @@ export class MenuItem {
    * @param subMenu
    */
   constructor(
-    public subMenu?: MenuGroup,
+    public subMenu: MenuGroup | null = null,
   ) {
     this.registerSubMenu()
   }
@@ -78,6 +78,13 @@ export class MenuItem {
   }
 
   /**
+   * Detach from current MenuGroup
+   */
+  detach() {
+    // TODO
+  }
+
+  /**
    * Set a new sub menu
    * @param subMenu
    */
@@ -91,6 +98,6 @@ export class MenuItem {
    */
   removeSubMenu() {
     this.cleanup()
-    this.subMenu = undefined
+    this.subMenu = null
   }
 }

--- a/packages/core/src/menu/menuItem.ts
+++ b/packages/core/src/menu/menuItem.ts
@@ -48,12 +48,16 @@ export class MenuItem {
     if (!this.subMenu)
       return noop
 
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    const menuItem = this
+    const subMenu = this.subMenu
     const subMenuElement = this.subMenu.element
 
     hideStylableElement(subMenuElement)
 
     // initialize style
     subMenuElement.style.position = 'absolute'
+    // subMenuElement.style.transform = `translateX(${subMenu.offset.left}px, ${subMenu.offset.top}px)`
 
     const cleanups = [
       _addEventListener(
@@ -62,9 +66,8 @@ export class MenuItem {
         () => {
           // 1. determine the position.
           const position = checkPosition(
-            this.element.getBoundingClientRect(),
-            // TODO: display none doesn't work properly.
-            subMenuElement.getBoundingClientRect(),
+            menuItem,
+            subMenu,
             {
               width: defaultWindow!.innerWidth,
               height: defaultWindow!.innerHeight,
@@ -75,8 +78,8 @@ export class MenuItem {
             subMenuElement.style.setProperty(key, typeof value === 'number' ? `${value}px` : value)
             if (value === 0 && ['left', 'right'].includes(key)) {
               const directions = {
-                left: 'translateX(-100%)',
-                right: 'translateX(100%)',
+                left: 'translateX(calc(-100% - 20px))',
+                right: 'translateX(calc(100% + 20px))',
                 bottom: '',
                 top: '',
               } as const
@@ -144,5 +147,15 @@ export class MenuItem {
     this.subMenu?.element.remove()
 
     this.subMenu = null
+  }
+
+  dispose() {
+    // dispose sub menu,
+    // so that we could cause a chained dispose.
+    this.subMenu?.dispose()
+
+    this.removeSubMenu() // remove sub menu
+    this.detach() // remove from parent menu
+    this.element.remove() // remove from the DOM
   }
 }

--- a/packages/core/src/menu/menuItem.ts
+++ b/packages/core/src/menu/menuItem.ts
@@ -93,6 +93,11 @@ export class MenuItem {
         'mouseleave',
         () => hideStylableElement(subMenuElement),
       ),
+      _addEventListener(
+        this.element,
+        'click',
+        () => hideStylableElement(subMenuElement),
+      ),
     ]
     this.cleanup = () => {
       hideStylableElement(subMenuElement)

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1,5 +1,7 @@
 import type { Position, Size } from '@contextmenu/shared'
 import type { Offset, OffsetType } from './contextMenu'
+import type { MenuGroup } from './menu/menuGroup'
+import type { MenuItem } from './menu/MenuItem'
 
 /**
  * Calculate the `position: fixed/absolute` position offset of {@link menuSize}
@@ -40,16 +42,23 @@ export function calculateOffset(
  * @param containerSize
  */
 export function checkPosition(
-  item: DOMRect,
-  sumMenu: DOMRect,
+  menuItem: MenuItem,
+  subMenu: MenuGroup,
   containerSize: Size,
 ) {
+  const offset = subMenu.offset
+  const itemRect = menuItem.element.getBoundingClientRect()
+  const subMenuRect = subMenu.element.getBoundingClientRect()
+
+  const subMenuWidth = subMenuRect.width + offset.left
+  const subMenuHeight = subMenuRect.height + offset.top
+
   // TODO: able to give an custom offset(left, right, top, bottom)
   // if zero(left, right), make a 100% translate for that direction
   let [left, top, right, bottom] = [null, 0, 0, null] as Array<number | null>
-  const overflowX = item.right + sumMenu.width > containerSize.width
+  const overflowX = itemRect.right + subMenuWidth > containerSize.width
 
-  const overflowY = item.top + sumMenu.height > containerSize.height
+  const overflowY = itemRect.top + subMenuHeight > containerSize.height
 
   if (overflowX)
     [left, right] = [0, null]

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -9,7 +9,11 @@ import type { Offset, OffsetType } from './contextMenu'
  * @param containerSize container size that contains the menu
  * @returns
  */
-export function calculateOffset(mousePosition: Position, menuSize: Size, containerSize: Size): Offset {
+export function calculateOffset(
+  mousePosition: Position,
+  menuSize: Size,
+  containerSize: Size,
+): Offset {
   let [left, top, right, bottom]: OffsetType[] = [mousePosition.x, mousePosition.y, null, null]
 
   const overflowX = mousePosition.x + menuSize.width > containerSize.width
@@ -25,6 +29,39 @@ export function calculateOffset(mousePosition: Position, menuSize: Size, contain
     left,
     right,
     top,
+    bottom,
+  }
+}
+
+/**
+ * Check position of a sub menu
+ * @param itemSize
+ * @param menuSize
+ * @param containerSize
+ */
+export function checkPosition(
+  item: DOMRect,
+  sumMenu: DOMRect,
+  containerSize: Size,
+) {
+  // TODO: able to give an custom offset(left, right, top, bottom)
+  // if zero(left, right), make a 100% translate for that direction
+  let [left, top, right, bottom] = [null, 0, 0, null] as Array<number | null>
+  const overflowX = item.right + sumMenu.width > containerSize.width
+
+  const overflowY = item.top + sumMenu.height > containerSize.height
+
+  if (overflowX)
+    [left, right] = [0, null]
+
+  if (overflowY)
+    // TODO: implement MacOS like vertical positioning
+    [top, bottom] = [null, 0]
+
+  return {
+    left,
+    top,
+    right,
     bottom,
   }
 }

--- a/packages/shared/src/element.ts
+++ b/packages/shared/src/element.ts
@@ -15,8 +15,8 @@ export const isStylableElement = (el: Element): el is StylableElement => {
 }
 
 export const hideStylableElement = (el: StylableElement) => {
-  el.style.display = 'none'
+  el.style.visibility = 'hidden'
 }
 export const showStylableElement = (el: StylableElement) => {
-  el.style.display = 'block'
+  el.style.visibility = 'visible'
 }

--- a/playground/vanilla/src/menu.ts
+++ b/playground/vanilla/src/menu.ts
@@ -57,7 +57,12 @@ export function createElement(template: string) {
 }
 
 function createNestedMenu(prefix = 'item') {
-  const menu = new MenuGroup()
+  const menu = new MenuGroup(undefined, {
+    offset: {
+      left: 20,
+      top: 20,
+    },
+  })
 
   const items = Array.from({ length: 3 }, (_, i) => {
     const item = new MenuItem()

--- a/playground/vanilla/src/menu.ts
+++ b/playground/vanilla/src/menu.ts
@@ -1,4 +1,4 @@
-import { createContextMenu } from '@contextmenu/core'
+import { MenuGroup, MenuItem, createContextMenu } from '@contextmenu/core'
 
 function initGlobalMenuElement() {
   document.querySelector<HTMLDivElement>('#app')!.append(createElement(`
@@ -13,8 +13,16 @@ function initGlobalMenuElement() {
 
 export function setupGlobalMenu() {
   initGlobalMenuElement()
-  const menu = document.getElementById('globalMenu')!
-  return createContextMenu(menu)
+  // const menu = document.getElementById('globalMenu')!
+
+  const nestedMenu = createNestedMenu()
+  nestedMenu.element.classList.add('nested-menu')
+  const subMenu = createNestedMenu('nested')
+  const items = [...nestedMenu.menuItems.values()]
+
+  items[1].setSubMenu(subMenu)
+
+  return createContextMenu(nestedMenu.element)
 }
 
 function initTargetMenuElement() {
@@ -46,4 +54,18 @@ const container = /* #__PURE__ */ document.createElement('div')
 export function createElement(template: string) {
   container.innerHTML = template
   return container.firstElementChild!
+}
+
+function createNestedMenu(prefix = 'item') {
+  const menu = new MenuGroup()
+
+  const items = Array.from({ length: 3 }, (_, i) => {
+    const item = new MenuItem()
+    item.element.append(createElement(`<p>${prefix}-${i}</p>`))
+    return item
+  })
+
+  menu.add(...items)
+
+  return menu
 }

--- a/playground/vanilla/src/style.css
+++ b/playground/vanilla/src/style.css
@@ -95,3 +95,6 @@ button:focus-visible {
     background-color: #f9f9f9;
   }
 }
+.nested-menu div {
+  border: 1px solid #eee;
+}

--- a/playground/vanilla/src/style.css
+++ b/playground/vanilla/src/style.css
@@ -98,3 +98,6 @@ button:focus-visible {
 .nested-menu div {
   border: 1px solid #eee;
 }
+.nested-menu div p {
+  cursor: pointer;
+}

--- a/tests/menu.test.ts
+++ b/tests/menu.test.ts
@@ -24,9 +24,9 @@ describe('MenuGroup & MenuItem', () => {
 
   describe('MenuGroup', () => {
     it('should add item', () => {
-      expect(group.menuItems.length).toBe(3)
+      expect(group.menuItems.size).toBe(3)
 
-      items.forEach(item => expect(group.menuItems.includes(item)).toBeTruthy())
+      items.forEach(item => expect(group.menuItems.has(item)).toBeTruthy())
     })
   })
 
@@ -36,7 +36,7 @@ describe('MenuGroup & MenuItem', () => {
       // group.add(item)
       item.attach(group)
 
-      expect(group.menuItems.includes(item)).toBeTruthy()
+      expect(group.menuItems.has(item)).toBeTruthy()
     })
 
     it('should set/remove sub menu afterwards', () => {
@@ -48,7 +48,7 @@ describe('MenuGroup & MenuItem', () => {
 
       item.removeSubMenu()
 
-      expect(item.subMenu).toBeUndefined()
+      expect(item.subMenu).toBeNull()
     })
 
     it('should show sub menu', () => {

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -8,9 +8,11 @@ export const mouseLeave = (el: EventTarget) => {
 }
 
 export const expectToBeVisible = (el: StylableElement) => {
-  expect(el.style.display).toBe('block')
+  // expect(el.style.display).toBe('block')
+  expect(el.style.visibility).toBe('visible')
 }
 
 export const expectToBeHidden = (el: StylableElement) => {
-  expect(el.style.display).toBe('none')
+  // expect(el.style.display).toBe('none')
+  expect(el.style.visibility).toBe('hidden')
 }


### PR DESCRIPTION
## Description
closes #5 
Now we're able to add sub menu for menu items, even **nested** sub menus.

```shell
MenuGroup -> [MenuItem, MenuItem, MenuItem]

MenuItem -> *MenuGroup(optional)
```
![image](https://user-images.githubusercontent.com/30516060/193228185-969a2926-a49a-4e04-9a1a-e48e96beaac1.png)


Customizability improved! 🎉